### PR TITLE
My edits

### DIFF
--- a/code/filter_keywords.py
+++ b/code/filter_keywords.py
@@ -173,8 +173,6 @@ def filter_keyword_parallel():
             # Check for missing months in the raw data
             expected_months = [f"{m:02d}" for m in range(1, 13)]
             missing_months = [m for m in expected_months if m not in files_by_month]
-            print(files_by_month)
-            print(expected_months)
             if missing_months:
                 error_msg = f"Error: Missing files for months {missing_months} in year {year}"
                 log_report(error_msg)

--- a/code/filter_keywords.py
+++ b/code/filter_keywords.py
@@ -50,7 +50,7 @@ with open(report_file_path, mode, encoding='utf-8', newline='') as report_file:
         writer.writerow(["Timestamp", "Message"])
 
 def log_report(message):
-    timestamp = datetime.now().strftime('%-m/%-d/%Y %H:%M')
+    timestamp = datetime.now().strftime('%m/%d/%Y %H:%M')
     with open(report_file_path, 'a', encoding='utf-8', newline='') as report_file:
         writer = csv.writer(report_file, delimiter='\t')
         writer.writerow([timestamp, message])
@@ -165,7 +165,7 @@ def filter_keyword_parallel():
                 if str(year) in file and file.endswith(".zst") and file.split('.zst')[0] not in processed_files:
                     try:
                         # Assuming filename format includes month as "YYYY-MM" or "YYYY-MM-..."
-                        month = file.split('-')[1]
+                        month = file.split('-')[1].split('.zst')[0]
                     except IndexError:
                         continue
                     files_by_month.setdefault(month, []).append(file)
@@ -173,6 +173,8 @@ def filter_keyword_parallel():
             # Check for missing months in the raw data
             expected_months = [f"{m:02d}" for m in range(1, 13)]
             missing_months = [m for m in expected_months if m not in files_by_month]
+            print(files_by_month)
+            print(expected_months)
             if missing_months:
                 error_msg = f"Error: Missing files for months {missing_months} in year {year}"
                 log_report(error_msg)

--- a/code/filter_sample.py
+++ b/code/filter_sample.py
@@ -14,7 +14,7 @@ args = get_args()
 years = parse_range(args.years)
 
 # Increase the field size limit to handle larger fields
-csv.field_size_limit(sys.maxsize)
+csv.field_size_limit(2**31 - 1)
 
 ### sampling hyper-parameters
 num_annot = 2
@@ -25,7 +25,7 @@ language_filtered_path = os.path.join(dir_path.replace("code","data\\data_reddit
 file_list = []
 for year in years:
     for month in range(1,13):
-        path_ = language_filtered_path+"\\RC_{}-{}.csv".format(year,month)
+        path_ = language_filtered_path+"\\RC_{}-{:02d}.csv".format(year,month)
         if os.path.exists(path_):
             file_list.append(path_)
         else:
@@ -201,7 +201,7 @@ def filter_sample_write(all_samples):
     # ========================================
     for annot in range(num_annot):
         sample_file_path = os.path.join(dir_path, f"filter_sample_{args.group}_{annot}.csv")
-        sample_key_file_path = os.path.join(dir_path, f"filter_sample_{args.group}_{annot}.csv")
+        sample_key_file_path = os.path.join(dir_path, f"filter_sample_key_{args.group}_{annot}.csv")
         
         with open(sample_file_path, "w", encoding='utf-8', newline='') as sample_file, \
             open(sample_key_file_path, "w", encoding='utf-8', newline='') as sample_file_key:
@@ -239,7 +239,8 @@ def filter_sample_write(all_samples):
 if __name__ == "__main__":
     start_time = time.time()
     for year in years:
-        filter_sample_year(year,file_list)
+        year_file_list = [f for f in file_list if f"RC_{year}-" in f]
+        filter_sample_year(year, year_file_list)
     filter_sample_write(all_samples)
     print(f"Reservoir sampling for the {args.group} social group from {args.years} was finished in {(time.time() - start_time) / 60:.2f} minutes. Total samples per each of the {num_annot} annotators: {len(all_samples[0])}")
 


### PR DESCRIPTION
filter_keywords
- Timestamp calculation changed to be compatible with Windows.

filter_sample
- Changed the csv.field_size_limit to be smaller. It seems like this function can't handle numbers that large.
- Fixed the method used to retrieve the files from filter_language. We were not padding the month for single-digit months, which is the method used in filter_keywords.
- Fixed the naming for sample_key_file_path so it doesn't save over sample_file_path.
- Changed filter_sample_year's call to include only entries from one year.

